### PR TITLE
feature(0.0.0): Add basic logging for commands

### DIFF
--- a/src/main/kotlin/com/supergrecko/questionbot/commands/AnswerCommands.kt
+++ b/src/main/kotlin/com/supergrecko/questionbot/commands/AnswerCommands.kt
@@ -4,12 +4,13 @@ import com.supergrecko.questionbot.arguments.QuestionArg
 import com.supergrecko.questionbot.dataclasses.BotConfig
 import com.supergrecko.questionbot.extensions.PermissionLevel
 import com.supergrecko.questionbot.extensions.permission
+import com.supergrecko.questionbot.services.LogService
 import me.aberrantfox.kjdautils.api.dsl.CommandSet
 import me.aberrantfox.kjdautils.api.dsl.commands
 import me.aberrantfox.kjdautils.internal.arguments.SentenceArg
 
 @CommandSet("responses")
-fun answerCommands(config: BotConfig) = commands {
+fun answerCommands(config: BotConfig, logService: LogService) = commands {
     command("reply") {
         description = "Reply to a question"
         requiresGuild = true
@@ -18,6 +19,7 @@ fun answerCommands(config: BotConfig) = commands {
         expect(QuestionArg, SentenceArg)
 
         execute {
+            logService.log(it)
 
         }
     }

--- a/src/main/kotlin/com/supergrecko/questionbot/commands/ManageCommands.kt
+++ b/src/main/kotlin/com/supergrecko/questionbot/commands/ManageCommands.kt
@@ -4,6 +4,7 @@ import com.supergrecko.questionbot.arguments.QuestionArg
 import com.supergrecko.questionbot.extensions.PermissionLevel
 import com.supergrecko.questionbot.extensions.permission
 import com.supergrecko.questionbot.services.ConfigService
+import com.supergrecko.questionbot.services.LogService
 import me.aberrantfox.kjdautils.api.dsl.CommandSet
 import me.aberrantfox.kjdautils.api.dsl.commands
 import me.aberrantfox.kjdautils.api.dsl.embed
@@ -15,7 +16,7 @@ import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
 @CommandSet("manage")
-fun manageCommands(config: ConfigService) = commands {
+fun manageCommands(config: ConfigService, logService: LogService) = commands {
     command("setrole") {
         description = "Set the lowest required role to invoke commands."
         requiresGuild = true
@@ -24,6 +25,7 @@ fun manageCommands(config: ConfigService) = commands {
         expect(RoleArg)
 
         execute {
+            logService.log(it)
             val (role) = it.args
 
             // TODO: Implement it
@@ -39,6 +41,7 @@ fun manageCommands(config: ConfigService) = commands {
         expect(WordArg)
 
         execute {
+            logService.log(it)
             config.setPrefix(it.args.first() as String)
             config.save()
 
@@ -62,6 +65,7 @@ fun manageCommands(config: ConfigService) = commands {
         expect(MessageArg)
 
         execute {
+            logService.log(it)
 
         }
     }
@@ -74,6 +78,7 @@ fun manageCommands(config: ConfigService) = commands {
         expect(MessageArg, QuestionArg)
 
         execute {
+            logService.log(it)
 
         }
     }

--- a/src/main/kotlin/com/supergrecko/questionbot/commands/QuestionCommands.kt
+++ b/src/main/kotlin/com/supergrecko/questionbot/commands/QuestionCommands.kt
@@ -4,13 +4,14 @@ import com.supergrecko.questionbot.arguments.QuestionArg
 import com.supergrecko.questionbot.dataclasses.BotConfig
 import com.supergrecko.questionbot.extensions.PermissionLevel
 import com.supergrecko.questionbot.extensions.permission
+import com.supergrecko.questionbot.services.LogService
 import me.aberrantfox.kjdautils.api.dsl.CommandSet
 import me.aberrantfox.kjdautils.api.dsl.commands
 import me.aberrantfox.kjdautils.internal.arguments.SentenceArg
 import me.aberrantfox.kjdautils.internal.arguments.TextChannelArg
 
 @CommandSet("questions")
-fun questionCommands(config: BotConfig) = commands {
+fun questionCommands(config: BotConfig, logService: LogService) = commands {
     command("ask") {
         description = "Ask the channel a question."
         requiresGuild = true
@@ -19,8 +20,8 @@ fun questionCommands(config: BotConfig) = commands {
         expect(TextChannelArg, SentenceArg)
 
         execute {
+            logService.log(it)
             val (id, question) = it.args
-
             // TODO: Implement
             it.respond("Id: $id, Question: $question")
         }
@@ -34,7 +35,8 @@ fun questionCommands(config: BotConfig) = commands {
         expect(QuestionArg, SentenceArg)
 
         execute {
-
+            logService.log(it)
+            it.respond("test")
         }
     }
 
@@ -46,7 +48,7 @@ fun questionCommands(config: BotConfig) = commands {
         expect(QuestionArg)
 
         execute {
-
+            logService.log(it)
         }
     }
 }

--- a/src/main/kotlin/com/supergrecko/questionbot/dataclasses/BotConfig.kt
+++ b/src/main/kotlin/com/supergrecko/questionbot/dataclasses/BotConfig.kt
@@ -28,6 +28,7 @@ data class GuildConfig(
         var guild: String = "<missing role>",
         var role: String = "<missing id>",
         var count: Int = 0,
+        var logChannel: String = "<missing log channel id>",
         val questions: MutableList<Question> = mutableListOf()
 )
 

--- a/src/main/kotlin/com/supergrecko/questionbot/services/LogService.kt
+++ b/src/main/kotlin/com/supergrecko/questionbot/services/LogService.kt
@@ -1,0 +1,32 @@
+package com.supergrecko.questionbot.services
+
+import com.supergrecko.questionbot.dataclasses.BotConfig
+import me.aberrantfox.kjdautils.api.annotation.Service
+import me.aberrantfox.kjdautils.api.dsl.CommandEvent
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.TextChannel
+import me.aberrantfox.kjdautils.api.dsl.embed
+import java.awt.Color
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+@Service
+class LogService(val config: BotConfig) {
+    fun log(event: CommandEvent) = retrieveLoggingChannel(event.guild!!)?.sendMessage(createEmbed(event))?.queue()
+
+    private fun createEmbed(event: CommandEvent) = embed {
+        var jumpToLink: String = "https://discordapp.com/channels/${event.guild?.id}/${event.channel.id}/${event.message.id}"
+        color = Color(0xfb8c00)
+        thumbnail = event.author.effectiveAvatarUrl
+        title = "New Command: ${event.commandStruct.commandName}"
+        description = event.message.contentRaw
+        addInlineField("Invoked By", "${event.author.name}")
+        addInlineField("Date", LocalDateTime.now().format(DateTimeFormatter.ISO_DATE))
+        addField("Goto:", jumpToLink)
+    }
+
+    private fun retrieveLoggingChannel(guild: Guild): TextChannel? {
+        val channelId = config.guilds[0].logChannel.takeIf { it.isNotEmpty() } ?: return null
+        return guild.jda.getTextChannelById(channelId)
+    }
+}


### PR DESCRIPTION
# Add Basic Logging for commands

#1 

This PR adds a new Service to log commands that are entered by the user to a separate logging channel. 

The message will contain the command that was asked, the detail of the message, the user, the Date of the message and a link to go to the message in the channel it was added.

![image](https://user-images.githubusercontent.com/1348165/65084796-4959da00-d9a4-11e9-8a60-b5e6abdafc6a.png)


Added: 
- New service: `LogService`
- Updated commands to call `LogService.log` with the `CommandEvent`

### Note: After this PR, you will need to create a new channel for the Logs to be sent, and add the ID to the config