### PR TITLE
feature(0.0.0): add toggle for logging

### DIFF
--- a/commands.md
+++ b/commands.md
@@ -11,12 +11,14 @@
 | help     | (Word)    | Display a help menu |
 
 ## manage
-| Commands  | Arguments           | Description                                                       |
-| --------- | ------------------- | ----------------------------------------------------------------- |
-| addanswer | MessageID, Question | Manually add an already existing message as a reply to a question |
-| delanswer | MessageID           | Delete an answer from a question.                                 |
-| setprefix | Word                | Sets the bot prefix.                                              |
-| setrole   | Role                | Set the lowest required role to invoke commands.                  |
+| Commands      | Arguments           | Description                                                       |
+| ------------- | ------------------- | ----------------------------------------------------------------- |
+| addanswer     | MessageID, Question | Manually add an already existing message as a reply to a question |
+| delanswer     | MessageID           | Delete an answer from a question.                                 |
+| enablelogging | On or Off           | Enables / Disables bot logging                                    |
+| setlog        | TextChannel         | Sets the log channel.                                             |
+| setprefix     | Word                | Sets the bot prefix.                                              |
+| setrole       | Role                | Set the lowest required role to invoke commands.                  |
 
 ## questions
 | Commands | Arguments                     | Description                 |

--- a/src/main/kotlin/com/supergrecko/questionbot/commands/ManageCommands.kt
+++ b/src/main/kotlin/com/supergrecko/questionbot/commands/ManageCommands.kt
@@ -11,6 +11,7 @@ import me.aberrantfox.kjdautils.api.dsl.embed
 import me.aberrantfox.kjdautils.internal.arguments.MessageArg
 import me.aberrantfox.kjdautils.internal.arguments.RoleArg
 import me.aberrantfox.kjdautils.internal.arguments.WordArg
+import me.aberrantfox.kjdautils.internal.arguments.*
 import java.awt.Color
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -51,6 +52,54 @@ fun manageCommands(config: ConfigService, logService: LogService) = commands {
                 description = "Bot Prefix has successfully been updated."
 
                 addInlineField("New Prefix", it.args.first() as String)
+                addInlineField("Invoked By", it.author.name)
+                addInlineField("Date", LocalDateTime.now().format(DateTimeFormatter.ISO_DATE))
+            })
+        }
+    }
+
+    command("setlog") {
+        description = "Sets the log channel."
+        requiresGuild = true
+        permission = PermissionLevel.ADMIN
+
+        expect(TextChannelArg)
+
+        execute {
+            logService.log(it)
+            config.setLogChannel(it.guild?.id!!, it.args.first() as String)
+            config.save()
+
+            it.respond(embed {
+                color = Color(0xfb8c00)
+                title = "Success!"
+                description = "Log Channel has successfully been updated."
+
+                addInlineField("New Channel", it.args.first() as String)
+                addInlineField("Invoked By", it.author.name)
+                addInlineField("Date", LocalDateTime.now().format(DateTimeFormatter.ISO_DATE))
+            })
+        }
+    }
+    command("enablelogging") {
+        description = "Enables / Disables bot logging"
+        requiresGuild = true
+        permission = PermissionLevel.ADMIN
+
+        expect(OnOffArg)
+        execute {
+            logService.log(it)
+            val isOn = it.args.component1() as Boolean
+
+            config.enableLogging(it.guild?.id!!, isOn)
+            config.save()
+
+            it.respond(embed {
+                color = Color(0xfb8c00)
+                title = "Success!"
+                description = "Logging settings have successfully been updated."
+
+                addInlineField("New Value", if (isOn) "on" else "off")
                 addInlineField("Invoked By", it.author.name)
                 addInlineField("Date", LocalDateTime.now().format(DateTimeFormatter.ISO_DATE))
             })

--- a/src/main/kotlin/com/supergrecko/questionbot/dataclasses/BotConfig.kt
+++ b/src/main/kotlin/com/supergrecko/questionbot/dataclasses/BotConfig.kt
@@ -1,6 +1,7 @@
 package com.supergrecko.questionbot.dataclasses
 
 import me.aberrantfox.kjdautils.api.annotation.Data
+import me.aberrantfox.kjdautils.internal.arguments.OnOffArg
 
 /**
  * Represent the bot configuration
@@ -29,6 +30,7 @@ data class GuildConfig(
         var role: String = "<missing id>",
         var count: Int = 0,
         var logChannel: String = "<missing channel>",
+        var loggingEnabled: Boolean = true,
         val questions: MutableList<Question> = mutableListOf()
 )
 

--- a/src/main/kotlin/com/supergrecko/questionbot/dataclasses/BotConfig.kt
+++ b/src/main/kotlin/com/supergrecko/questionbot/dataclasses/BotConfig.kt
@@ -1,7 +1,6 @@
 package com.supergrecko.questionbot.dataclasses
 
 import me.aberrantfox.kjdautils.api.annotation.Data
-import me.aberrantfox.kjdautils.internal.arguments.OnOffArg
 
 /**
  * Represent the bot configuration

--- a/src/main/kotlin/com/supergrecko/questionbot/services/ConfigService.kt
+++ b/src/main/kotlin/com/supergrecko/questionbot/services/ConfigService.kt
@@ -4,6 +4,8 @@ import com.supergrecko.questionbot.dataclasses.BotConfig
 import com.supergrecko.questionbot.dataclasses.GuildConfig
 import me.aberrantfox.kjdautils.api.annotation.Service
 import me.aberrantfox.kjdautils.discord.Discord
+import me.aberrantfox.kjdautils.internal.arguments.OnOffArg
+import me.aberrantfox.kjdautils.internal.arguments.YesNoArg
 import me.aberrantfox.kjdautils.internal.di.PersistenceService
 
 @Service
@@ -17,6 +19,25 @@ open class ConfigService(val config: BotConfig, private val discord: Discord, pr
         config.prefix = prefix
         discord.configuration.prefix = prefix
     }
+
+    /**
+     * Set the log channel to be used
+     *
+     * @param channelId the channel id to be used
+     */
+    fun setLogChannel(guild: String, channelId: String) {
+        config.guilds.find { it.guild == guild }?.logChannel = channelId
+    }
+    /**
+     * Set the log channel to be used
+     *
+     * @param guildId the id of the guild
+     * @param enabled on / off to enable or disable logging
+     */
+    fun enableLogging(guildId: String, enabled: Boolean) {
+        config.guilds.find { it.guild == guildId }?.loggingEnabled = enabled
+    }
+
 
     /**
      * Alias PersistenceService#save

--- a/src/main/kotlin/com/supergrecko/questionbot/services/ConfigService.kt
+++ b/src/main/kotlin/com/supergrecko/questionbot/services/ConfigService.kt
@@ -4,8 +4,6 @@ import com.supergrecko.questionbot.dataclasses.BotConfig
 import com.supergrecko.questionbot.dataclasses.GuildConfig
 import me.aberrantfox.kjdautils.api.annotation.Service
 import me.aberrantfox.kjdautils.discord.Discord
-import me.aberrantfox.kjdautils.internal.arguments.OnOffArg
-import me.aberrantfox.kjdautils.internal.arguments.YesNoArg
 import me.aberrantfox.kjdautils.internal.di.PersistenceService
 import net.dv8tion.jda.internal.entities.TextChannelImpl
 
@@ -32,7 +30,7 @@ open class ConfigService(val config: BotConfig, private val discord: Discord, pr
     }
 
     /**
-     * Set the log channel to be used
+     * Set logging to on or off
      *
      * @param guildId the id of the guild
      * @param enabled on / off to enable or disable logging

--- a/src/main/kotlin/com/supergrecko/questionbot/services/LogService.kt
+++ b/src/main/kotlin/com/supergrecko/questionbot/services/LogService.kt
@@ -5,13 +5,18 @@ import me.aberrantfox.kjdautils.api.annotation.Service
 import me.aberrantfox.kjdautils.api.dsl.CommandEvent
 import net.dv8tion.jda.api.entities.TextChannel
 import me.aberrantfox.kjdautils.api.dsl.embed
+import me.aberrantfox.kjdautils.internal.arguments.OnOffArg
 import java.awt.Color
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
 @Service
 class LogService(val config: BotConfig) {
-    fun log(event: CommandEvent) = retrieveLoggingChannel(event)?.sendMessage(createEmbed(event))?.queue()
+    fun log(event: CommandEvent) {
+        val logsEnabled = config.guilds.find { it.guild == event.guild?.id }?.loggingEnabled
+        if (!logsEnabled!!) return
+        retrieveLoggingChannel(event)?.sendMessage(createEmbed(event))?.queue()
+    }
 
     private fun createEmbed(event: CommandEvent) = embed {
         val jumpToLink = "https://discordapp.com/channels/${event.guild?.id}/${event.channel.id}/${event.message.id}"


### PR DESCRIPTION
# feature(0.0.0): add toggle for logging

Add a new command: `$enablelogging` to enable / disable the logging of bot commands into the log channel. This configuration is saved per guild, and has a default of true.

![image](https://user-images.githubusercontent.com/1348165/65151831-c7f35d80-da1e-11e9-9ab7-d1f610df60b6.png)
