### PR TITLE
refactor(0.0.0): Remove embeds from command responses and clean up log embed

### DIFF
--- a/src/main/kotlin/com/supergrecko/questionbot/commands/ManageCommands.kt
+++ b/src/main/kotlin/com/supergrecko/questionbot/commands/ManageCommands.kt
@@ -7,16 +7,12 @@ import com.supergrecko.questionbot.services.ConfigService
 import com.supergrecko.questionbot.tools.Arguments
 import me.aberrantfox.kjdautils.api.dsl.CommandSet
 import me.aberrantfox.kjdautils.api.dsl.commands
-import me.aberrantfox.kjdautils.api.dsl.embed
 import me.aberrantfox.kjdautils.internal.arguments.RoleArg
 import me.aberrantfox.kjdautils.internal.arguments.TextChannelArg
 import me.aberrantfox.kjdautils.internal.arguments.WordArg
 import me.aberrantfox.kjdautils.internal.arguments.OnOffArg
 import me.aberrantfox.kjdautils.internal.arguments.MessageArg
 import net.dv8tion.jda.internal.entities.TextChannelImpl
-import java.awt.Color
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
 
 @CommandSet("manage")
 fun manageCommands(config: ConfigService) = commands {
@@ -41,18 +37,11 @@ fun manageCommands(config: ConfigService) = commands {
         expect(WordArg)
 
         execute {
-            config.setPrefix(it.args.first() as String)
+            val prefix = it.args.first() as String
+            config.setPrefix(prefix)
             config.save()
 
-            it.respond(embed {
-                color = Color(0xfb8c00)
-                title = "Success!"
-                description = "Bot Prefix has successfully been updated."
-
-                addInlineField("New Prefix", it.args.first() as String)
-                addInlineField("Invoked By", it.author.name)
-                addInlineField("Date", LocalDateTime.now().format(DateTimeFormatter.ISO_DATE))
-            })
+            it.respond("Success, the bot prefix has been set to `$prefix`.")
         }
     }
 
@@ -69,15 +58,7 @@ fun manageCommands(config: ConfigService) = commands {
 
             config.setQuestionChannel(it.guild?.id!!, channel!!)
 
-            it.respond(embed {
-                color = Color(0xfb8c00)
-                title = "Success!"
-                description = "Questions Channel has successfully been updated."
-
-                addInlineField("New Channel", (it.args.first() as TextChannelImpl).id)
-                addInlineField("Invoked By", it.author.name)
-                addInlineField("Date", LocalDateTime.now().format(DateTimeFormatter.ISO_DATE))
-            })
+            it.respond("Success, the question output channel has been set to ${channel.asMention}.")
         }
     }
 
@@ -94,15 +75,7 @@ fun manageCommands(config: ConfigService) = commands {
 
             config.setLogChannel(it.guild?.id!!, channel!!)
 
-            it.respond(embed {
-                color = Color(0xfb8c00)
-                title = "Success!"
-                description = "Log Channel has successfully been updated."
-
-                addInlineField("New Channel", (it.args.first() as TextChannelImpl).id)
-                addInlineField("Invoked By", it.author.name)
-                addInlineField("Date", LocalDateTime.now().format(DateTimeFormatter.ISO_DATE))
-            })
+            it.respond("Success, the log output channel has been set to ${channel.asMention}.")
         }
     }
 
@@ -119,15 +92,7 @@ fun manageCommands(config: ConfigService) = commands {
 
             config.enableLogging(it.guild?.id!!, isOn)
 
-            it.respond(embed {
-                color = Color(0xfb8c00)
-                title = "Success!"
-                description = "Logging settings have successfully been updated."
-
-                addInlineField("New Value", if (isOn) "on" else "off")
-                addInlineField("Invoked By", it.author.name)
-                addInlineField("Date", LocalDateTime.now().format(DateTimeFormatter.ISO_DATE))
-            })
+            it.respond("Success, logging settings have successfully been updated.")
         }
     }
 

--- a/src/main/kotlin/com/supergrecko/questionbot/listeners/GuildJoinListener.kt
+++ b/src/main/kotlin/com/supergrecko/questionbot/listeners/GuildJoinListener.kt
@@ -1,7 +1,6 @@
 package com.supergrecko.questionbot.listeners
 
 import com.google.common.eventbus.Subscribe
-import com.supergrecko.questionbot.dataclasses.BotConfig
 import com.supergrecko.questionbot.services.InfoService
 import net.dv8tion.jda.api.events.guild.GuildJoinEvent
 

--- a/src/main/kotlin/com/supergrecko/questionbot/listeners/GuildLeaveListener.kt
+++ b/src/main/kotlin/com/supergrecko/questionbot/listeners/GuildLeaveListener.kt
@@ -1,7 +1,6 @@
 package com.supergrecko.questionbot.listeners
 
 import com.google.common.eventbus.Subscribe
-import com.supergrecko.questionbot.dataclasses.BotConfig
 import com.supergrecko.questionbot.services.InfoService
 import net.dv8tion.jda.api.events.guild.GuildLeaveEvent
 

--- a/src/main/kotlin/com/supergrecko/questionbot/services/LogService.kt
+++ b/src/main/kotlin/com/supergrecko/questionbot/services/LogService.kt
@@ -5,8 +5,6 @@ import me.aberrantfox.kjdautils.api.dsl.CommandEvent
 import net.dv8tion.jda.api.entities.TextChannel
 import me.aberrantfox.kjdautils.api.dsl.embed
 import java.awt.Color
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
 
 @Service
 class LogService(val config: ConfigService) {
@@ -35,13 +33,14 @@ class LogService(val config: ConfigService) {
         val link = "https://discordapp.com/channels/${event.guild?.id}/${event.channel.id}/${event.message.id}"
 
         color = Color(0xfb8c00)
-        thumbnail = event.author.effectiveAvatarUrl
-        title = "Command Invoked: ${event.commandStruct.commandName}"
-        description = event.message.contentRaw
+        title = "Command Invoked"
 
-        addInlineField("Invoked By", event.author.name)
-        addInlineField("Date", LocalDateTime.now().format(DateTimeFormatter.ISO_DATE))
-        addField("Link:", link)
+        addInlineField("Command", event.commandStruct.commandName)
+        addInlineField("Invoked By", event.author.asTag)
+        addInlineField("Author ID", event.author.id)
+        addField("Command Text", event.message.contentDisplay)
+
+        addField("Original Message", link)
     }
 
     /**


### PR DESCRIPTION
The logging embed has been revisited.

- Now displays discriminator
- Now displays author snowflake

- No longer displays avatar
- No longer displays date

![image](https://user-images.githubusercontent.com/42585241/65270120-cdce6900-db1a-11e9-842a-4439a9036b34.png)