### PR TITLE
feature(0.0.0): implement answer command

### DIFF
--- a/commands.md
+++ b/commands.md
@@ -20,15 +20,15 @@
 | setprefix     | Word                   | Sets the bot prefix.                                              |
 | setrole       | Role                   | Set the lowest required role to invoke commands.                  |
 
+## answer
+| Commands | Arguments      | Description       |
+| -------- | -------------- | ----------------- |
+| answer   | Question, Text | Answer a question |
+
 ## ask
 | Commands | Arguments                  | Description                 |
 | -------- | -------------------------- | --------------------------- |
 | ask      | (Separated|Text)           | Ask the channel a question. |
 | delete   | Question                   | Delete a question           |
 | edit     | Question, (Separated|Text) | Edit a question             |
-
-## answer
-| Commands | Arguments      | Description         |
-| -------- | -------------- | ------------------- |
-| reply    | Question, Text | Reply to a question |
 

--- a/src/main/kotlin/com/supergrecko/questionbot/commands/AnswerCommands.kt
+++ b/src/main/kotlin/com/supergrecko/questionbot/commands/AnswerCommands.kt
@@ -1,22 +1,40 @@
 package com.supergrecko.questionbot.commands
 
 import com.supergrecko.questionbot.arguments.QuestionArg
+import com.supergrecko.questionbot.dataclasses.AnswerDetails
+import com.supergrecko.questionbot.dataclasses.Question
 import com.supergrecko.questionbot.extensions.PermissionLevel
 import com.supergrecko.questionbot.extensions.permission
+import com.supergrecko.questionbot.services.AnswerService
+import com.supergrecko.questionbot.services.ConfigService
+import com.supergrecko.questionbot.tools.Arguments
 import me.aberrantfox.kjdautils.api.dsl.CommandSet
 import me.aberrantfox.kjdautils.api.dsl.commands
 import me.aberrantfox.kjdautils.internal.arguments.SentenceArg
 
 @CommandSet("answer")
-fun answerCommands() = commands {
-    command("reply") {
-        description = "Reply to a question"
+fun answerCommands(config: ConfigService, answerService: AnswerService) = commands {
+    command("answer") {
+        description = "Answer a question"
         requiresGuild = true
         permission = PermissionLevel.EVERYONE
 
         expect(QuestionArg, SentenceArg)
 
         execute {
+            val args = Arguments(it.args)
+            val question = args.asType<Question>(0)
+            val answer = args.asType<String>(1)
+            val state = config.getGuild(it.guild?.id!!)
+            val details = AnswerDetails(it.author, it.message.id, question!!.id, answer!!)
+            val channel = it.guild!!.getTextChannelById(state.config.channels.answers) ?: it.guild!!.textChannels.first()
+
+            if (answerService.questionAnsweredByUser(it.guild!!, details)) {
+                it.respond("You have already answered Question#${question!!.id}. Check #${channel.name}")
+            } else {
+                answerService.addAnswer(it.guild!!, details)
+                it.respond("Your answer has been posted in #${channel.name}")
+            }
         }
     }
 }

--- a/src/main/kotlin/com/supergrecko/questionbot/dataclasses/AnswerDetails.kt
+++ b/src/main/kotlin/com/supergrecko/questionbot/dataclasses/AnswerDetails.kt
@@ -1,0 +1,19 @@
+package com.supergrecko.questionbot.dataclasses
+
+import net.dv8tion.jda.api.entities.User
+
+
+/**
+ * Represent answer details that will be used to save and send answer
+ *
+ * @property sender the user that sent the answer
+ * @property invocationId the id of the $answer command sent
+ * @property questionId the id of the question that is being answered
+ * @property text the text content of the answer
+ */
+data class AnswerDetails(
+        var sender: User,
+        var invocationId: String = "",
+        var questionId: Int = 0,
+        var text: String = ""
+)

--- a/src/main/kotlin/com/supergrecko/questionbot/dataclasses/BotConfig.kt
+++ b/src/main/kotlin/com/supergrecko/questionbot/dataclasses/BotConfig.kt
@@ -73,6 +73,8 @@ data class Question(
         this.note = note
         this.question = question
     }
+
+    fun addAnswer(answer: Answer) = responses.add(answer)
 }
 
 /**
@@ -90,4 +92,12 @@ data class Answer(
         var reason: String = "This answer is still listed.",
         var invocation: String = "",
         var embed: String = ""
-)
+) {
+    fun setEmbedId(embedId: String) {
+        this.embed = embedId
+    }
+
+    fun setInvocationId(invocationId: String) {
+        this.invocation = invocationId
+    }
+}

--- a/src/main/kotlin/com/supergrecko/questionbot/services/AnswerService.kt
+++ b/src/main/kotlin/com/supergrecko/questionbot/services/AnswerService.kt
@@ -1,0 +1,100 @@
+package com.supergrecko.questionbot.services
+
+import com.supergrecko.questionbot.dataclasses.Answer
+import com.supergrecko.questionbot.dataclasses.AnswerDetails
+import com.supergrecko.questionbot.dataclasses.GuildConfig
+import com.supergrecko.questionbot.dataclasses.Question
+import me.aberrantfox.kjdautils.api.annotation.Service
+import me.aberrantfox.kjdautils.api.dsl.embed
+import net.dv8tion.jda.api.entities.Guild
+import java.awt.Color
+
+/**
+ * List of guilds, globally accessible
+ */
+private lateinit var guilds: MutableList<GuildConfig>
+
+@Service
+class AnswerService(val config: ConfigService) {
+    init {
+        // Hacky way to extract guilds from service
+        guilds = config.config.guilds
+    }
+
+    /**
+     * Adds a question to the passed guild
+     *
+     * @param guild the guild to add the question to
+     * @param answerDetails the answer details for the answer
+     */
+    fun addAnswer(guild: Guild, answerDetails: AnswerDetails) {
+        val state = config.getGuild(guild.id)
+        val question = state.getQuestion(answerDetails.questionId)
+        val answer = Answer(sender = answerDetails.sender.id, invocation = answerDetails.invocationId)
+
+        question.addAnswer(answer)
+        config.save()
+        sendAnswer(guild, question, answer, answerDetails)
+    }
+
+    /**
+     * Check if a user has already answered a given question
+     *
+     * @param guild the guild to add the question to
+     * @param answerDetails the answer details for the answer
+     */
+
+    fun questionAnsweredByUser(guild: Guild, answerDetails: AnswerDetails): Boolean {
+        val state = config.getGuild(guild.id)
+        val question = state.getQuestion(answerDetails.questionId)
+        if (question.responses.any { it.sender == answerDetails.sender.id }) {
+            return true
+        }
+        return false
+    }
+
+    /**
+     * Edits a question with the given guild and sends updated question to the given guild
+     *
+     * @param guild the guild to send a question from
+     * @param newText the new answer text
+     * @param embedId the id of the embed in the answers channel
+     */
+    fun editAnswer(guild: Guild, id: Int, newText: String, embedId: String) {
+
+    }
+
+    /**
+     * Sends a question from the given guild
+     *
+     * @param guild the guild to send a question from
+     * @param id the question id to send
+     */
+    private fun sendAnswer(guild: Guild, question: Question, answer: Answer, answerDetails: AnswerDetails) {
+        val state = config.getGuild(guild.id)
+        val channel = guild.getTextChannelById(state.config.channels.answers) ?: guild.textChannels.first()
+
+        channel.sendMessage(getEmbed(state, answerDetails)).queue {
+            it.addReaction("\uD83D\uDC4D").queue()
+            it.addReaction("\uD83D\uDC4E").queue()
+            answer.setEmbedId(it.id)
+            config.save()
+        }
+    }
+
+    /**
+     * Generate the RichEmbed for the given question
+     *
+     * @param state the guild to pull data from
+     * @param question the question
+     */
+    private fun getEmbed(state: QGuild, answerDetails: AnswerDetails) = embed {
+        val linkToQuestion = "https://discordapp.com/channels/${state.guild?.id}/${state.config.channels.questions}/${answerDetails.questionId}"
+
+        color = Color(0xfb8c00)
+        title = "${answerDetails.sender.asTag} has answered question (#${answerDetails.questionId})!"
+        description = answerDetails.text
+        addField("Question", linkToQuestion)
+    }
+
+}

--- a/src/main/kotlin/com/supergrecko/questionbot/services/QuestionService.kt
+++ b/src/main/kotlin/com/supergrecko/questionbot/services/QuestionService.kt
@@ -97,10 +97,10 @@ class QuestionService(val config: ConfigService) {
      */
     private fun getEmbed(state: QGuild, question: Question) = embed {
         val author = state.guild.getMemberById(question.sender)!!
+        val askChannel = state.guild.getTextChannelById(state.config.channels.questions) ?: state.guild.textChannels.first()
 
         color = Color(0xfb8c00)
         thumbnail = author.user.effectiveAvatarUrl
-
         title = "${author.fullName()} has asked a question! (#${question.id})"
         description = question.question
 
@@ -108,7 +108,8 @@ class QuestionService(val config: ConfigService) {
             addField("Notes:", question.note)
         }
 
-        addField("How to reply:", "todo this")
+        addField("How to reply:", "Invoke ${config.config.prefix}answer with the question id in #${askChannel.name}")
+        addField("Example","${config.config.prefix}answer ${question.id} This my answer to the question")
     }
 
 }


### PR DESCRIPTION
# feature(0.0.0): implement answer command

Complete a basic first implementation of the `$answer` command.

![image](https://user-images.githubusercontent.com/1348165/65286008-0def1500-db36-11e9-80e4-bd32b36451d4.png)
(shown with answer channel set to the same channel as the ask channel to make screenshot easier)

In this PR:
- Rename `$reply` to `$answer`.
- Add AnswerService to handle updating the responses in the question.
- Implement the `$answer` logic - add answer to channel with link to question and automatic reactions.
- Add check to only allow a user to answer each question once.
- Update the `$ask` command to show details on how to answer in the question embed.


