### PR TITLE
feature(0.0.0): Merge $question delete / ask and implement delete.

### DIFF
--- a/commands.md
+++ b/commands.md
@@ -26,9 +26,9 @@
 | answer   | Question, Text | Answer a question |
 
 ## ask
-| Commands | Arguments                   | Description                 |
-| -------- | --------------------------- | --------------------------- |
-| ask      | (Separated\|Text)           | Ask the channel a question. |
-| delete   | Question                    | Delete a question           |
-| edit     | Question, (Separated\|Text) | Edit a question             |
+| Commands       | Arguments                                | Description                 |
+| -------------- | ---------------------------------------- | --------------------------- |
+| ask            | (Separated\|Text)                        | Ask the channel a question. |
+| deletequestion | Question                                 | Delete a question           |
+| question       | ChoiceArg, Question, ((Separated\|Text)) | Edit or delete a question   |
 

--- a/src/main/kotlin/com/supergrecko/questionbot/dataclasses/BotConfig.kt
+++ b/src/main/kotlin/com/supergrecko/questionbot/dataclasses/BotConfig.kt
@@ -25,6 +25,7 @@ data class BotConfig(
  * @property count amount of questions asked in this guild
  * @property channels the channels to output to
  * @property loggingEnabled whether logging is enabled or not
+ * @property questions the questions asked in this guild
  */
 data class GuildConfig(
         var guild: String = "",
@@ -35,6 +36,7 @@ data class GuildConfig(
         val questions: MutableList<Question> = mutableListOf()
 ) {
     fun addQuestion(question: Question) = questions.add(question)
+    fun deleteQuestion(question: Question) = questions.removeAll { it.id == question.id }
 }
 
 /**

--- a/src/main/kotlin/com/supergrecko/questionbot/services/QuestionService.kt
+++ b/src/main/kotlin/com/supergrecko/questionbot/services/QuestionService.kt
@@ -4,7 +4,6 @@ import com.supergrecko.questionbot.dataclasses.GuildConfig
 import com.supergrecko.questionbot.dataclasses.Question
 import me.aberrantfox.kjdautils.api.annotation.Service
 import me.aberrantfox.kjdautils.api.dsl.embed
-import me.aberrantfox.kjdautils.extensions.jda.fullName
 import net.dv8tion.jda.api.entities.Guild
 import java.awt.Color
 
@@ -69,6 +68,22 @@ class QuestionService(val config: ConfigService) {
         config.save()
 
         channel.editMessageById(question.message, getEmbed(state, question)).queue()
+    }
+
+    /**
+     * Deletes a question from the given guild
+     *
+     * @param guild the guild to delete from
+     * @param id the question id to delete
+     */
+    fun deleteQuestion(guild: Guild, id: Int) {
+        val state = config.getGuild(guild.id)
+        val question = state.getQuestion(id)
+
+        state.guild.getTextChannelById(question.channel)!!.deleteMessageById(question.message).queue()
+
+        state.config.deleteQuestion(question)
+        config.save()
     }
 
     /**


### PR DESCRIPTION
Changes in this PR:

- `$question delete <QuestionID>` delete a question in a guild
- `$question edit <QuestionID> <SplitterArg>` edit a question inside a guild

The $edit command will be used for editing answers which is why these two commands were merged.
