### PR TITLE
refactor(0.0.0): Make Arguments.asType null safe and .fromList deal with errors

### DIFF
--- a/commands.md
+++ b/commands.md
@@ -26,9 +26,8 @@
 | answer   | Question, Text | Answer a question |
 
 ## ask
-| Commands       | Arguments                                | Description                 |
-| -------------- | ---------------------------------------- | --------------------------- |
-| ask            | (Separated\|Text)                        | Ask the channel a question. |
-| deletequestion | Question                                 | Delete a question           |
-| question       | ChoiceArg, Question, ((Separated\|Text)) | Edit or delete a question   |
+| Commands | Arguments                                | Description                 |
+| -------- | ---------------------------------------- | --------------------------- |
+| ask      | (Separated\|Text)                        | Ask the channel a question. |
+| question | ChoiceArg, Question, ((Separated\|Text)) | Edit or delete a question   |
 

--- a/src/main/kotlin/com/supergrecko/questionbot/commands/AnswerCommands.kt
+++ b/src/main/kotlin/com/supergrecko/questionbot/commands/AnswerCommands.kt
@@ -23,14 +23,16 @@ fun answerCommands(config: ConfigService, answerService: AnswerService) = comman
 
         execute {
             val args = Arguments(it.args)
+            // These will always exist
             val question = args.asType<Question>(0)
             val answer = args.asType<String>(1)
+
             val state = config.getGuild(it.guild?.id!!)
-            val details = AnswerDetails(it.author, it.message.id, question!!.id, answer!!)
+            val details = AnswerDetails(it.author, it.message.id, question.id, answer)
             val channel = it.guild!!.getTextChannelById(state.config.channels.answers) ?: it.guild!!.textChannels.first()
 
             if (answerService.questionAnsweredByUser(it.guild!!, details)) {
-                it.respond("You have already answered Question#${question!!.id}. Check ${channel.asMention}")
+                it.respond("You have already answered Question#${question.id}. Check ${channel.asMention}")
             } else {
                 answerService.addAnswer(it.guild!!, details)
                 it.respond("Your answer has been posted in ${channel.asMention}")

--- a/src/main/kotlin/com/supergrecko/questionbot/commands/ManageCommands.kt
+++ b/src/main/kotlin/com/supergrecko/questionbot/commands/ManageCommands.kt
@@ -22,9 +22,10 @@ fun manageCommands(config: ConfigService) = commands {
         expect(RoleArg)
 
         execute {
+            // These will always exist
             val args = Arguments(it.args)
             val role = args.asType<RoleImpl>(0)
-            config.setAdminRole(it.guild!!.id, role!!.name)
+            config.setAdminRole(it.guild!!.id, role.name)
 
             it.respond("Success, the minimum required role to invoke admin commands was set to `${role.name}`.")
         }
@@ -54,15 +55,17 @@ fun manageCommands(config: ConfigService) = commands {
 
         execute {
             val args = Arguments(it.args)
+            // These will always exist
             val command = args.asType<String>(0)
             val channel = args.asType<TextChannelImpl>(1)
 
             when (command) {
-                "log" -> config.setChannel(LogChannels.LOG, it.guild?.id!!, channel!!)
-                "questions" -> config.setChannel(LogChannels.QUESTION, it.guild?.id!!, channel!!)
-                "answers" -> config.setChannel(LogChannels.ANSWER, it.guild?.id!!, channel!!)
-                "replyto" -> config.setChannel(LogChannels.REPLYTO, it.guild?.id!!, channel!!)
+                "log" -> config.setChannel(LogChannels.LOG, it.guild?.id!!, channel)
+                "questions" -> config.setChannel(LogChannels.QUESTION, it.guild?.id!!, channel)
+                "answers" -> config.setChannel(LogChannels.ANSWER, it.guild?.id!!, channel)
+                "replyto" -> config.setChannel(LogChannels.REPLYTO, it.guild?.id!!, channel)
 
+                // Should be unreachable
                 else -> return@execute it.respond("Error, the option $command is not valid.")
             }
 
@@ -78,8 +81,9 @@ fun manageCommands(config: ConfigService) = commands {
         expect(ChoiceArg("ChoiceArg", "on", "off"))
 
         execute {
+            // These will always exist
             val args = Arguments(it.args)
-            val param = args.asType<String>(0)!!
+            val param = args.asType<String>(0)
 
             config.enableLogging(it.guild?.id!!, param == "on")
 

--- a/src/main/kotlin/com/supergrecko/questionbot/commands/QuestionCommands.kt
+++ b/src/main/kotlin/com/supergrecko/questionbot/commands/QuestionCommands.kt
@@ -49,24 +49,28 @@ fun questionCommands(config: ConfigService, questionService: QuestionService) = 
             val args = Arguments(it.args)
 
             when (args.asType<String>(0)) {
-                "edit" -> editQuestion(this, it, args, questionService)
-                "delete" -> deleteQuestion(this, it, args, questionService)
+                "edit" -> editQuestion(it, args, questionService)
+                "delete" -> deleteQuestion(it, args, questionService)
             }
         }
     }
 }
 
-private fun editQuestion(cmd: Command, event: CommandEvent, args: Arguments, service: QuestionService) {
+private fun editQuestion(event: CommandEvent, args: Arguments, service: QuestionService) {
     val id = args.asType<Question>(1)
     val (question, note) = args.fromList<String>(2, 0, 1)
 
-    service.editQuestion(event.guild!!, id!!.id, question ?: "No question was asked.", note ?: "")
+    service.editQuestion(event.guild!!, id.id, question ?: "No question was asked.", note ?: "")
     event.respond("Question #${id.id} has been edited.")
 }
 
-private fun deleteQuestion(cmd: Command, event: CommandEvent, args: Arguments, service: QuestionService) {
+private fun deleteQuestion(event: CommandEvent, args: Arguments, service: QuestionService) {
     val id = args.asType<Question>(1)
 
-    service.deleteQuestion(event.guild!!, id!!.id)
+    service.deleteQuestion(event.guild!!, id.id) {
+        event.respond("Question #${id.id} could not be found.")
+        return@deleteQuestion
+    }
+
     event.respond("Question #${id.id} has been deleted.")
 }

--- a/src/main/kotlin/com/supergrecko/questionbot/dataclasses/BotConfig.kt
+++ b/src/main/kotlin/com/supergrecko/questionbot/dataclasses/BotConfig.kt
@@ -36,7 +36,16 @@ data class GuildConfig(
         val questions: MutableList<Question> = mutableListOf()
 ) {
     fun addQuestion(question: Question) = questions.add(question)
-    fun deleteQuestion(question: Question) = questions.removeAll { it.id == question.id }
+    fun deleteQuestion(question: Question, orElse: () -> Unit = {}) {
+        val question = questions.find { it.id == question.id }
+
+        if (question != null) {
+            questions.remove(question)
+            return
+        }
+
+        orElse()
+    }
 }
 
 /**

--- a/src/main/kotlin/com/supergrecko/questionbot/services/ConfigService.kt
+++ b/src/main/kotlin/com/supergrecko/questionbot/services/ConfigService.kt
@@ -43,12 +43,10 @@ open class ConfigService(val config: BotConfig, private val discord: Discord, pr
         save()
     }
 
-    fun getGuild(guild: String): QGuild {
-        return QGuild(
-                guild = discord.jda.getGuildById(guild)!!,
-                config = getConfig(guild)
-        )
-    }
+    fun getGuild(guild: String) = QGuild(
+            guild = discord.jda.getGuildById(guild)!!,
+            config = getConfig(guild)
+    )
 
     fun setChannel(name: LogChannels, guild: String, channel: TextChannelImpl) {
         val settings = getConfig(guild).channels

--- a/src/main/kotlin/com/supergrecko/questionbot/services/QuestionService.kt
+++ b/src/main/kotlin/com/supergrecko/questionbot/services/QuestionService.kt
@@ -75,14 +75,15 @@ class QuestionService(val config: ConfigService) {
      *
      * @param guild the guild to delete from
      * @param id the question id to delete
+     * @param orElse code to be executed if the question did not exist
      */
-    fun deleteQuestion(guild: Guild, id: Int) {
+    fun deleteQuestion(guild: Guild, id: Int, orElse: () -> Unit = {}) {
         val state = config.getGuild(guild.id)
         val question = state.getQuestion(id)
 
         state.guild.getTextChannelById(question.channel)!!.deleteMessageById(question.message).queue()
 
-        state.config.deleteQuestion(question)
+        state.config.deleteQuestion(question, orElse)
         config.save()
     }
 

--- a/src/main/kotlin/com/supergrecko/questionbot/tools/Arguments.kt
+++ b/src/main/kotlin/com/supergrecko/questionbot/tools/Arguments.kt
@@ -2,8 +2,16 @@ package com.supergrecko.questionbot.tools
 
 open class Arguments(val args: List<Any?>) {
 
-    inline fun <reified T> asType(index: Int): T? {
-        return args.getOrNull(index) as? T
+    inline fun <reified T> asType(index: Int, onError: () -> Unit = {}): T {
+        val arg = args.getOrNull(index)
+
+        if (arg != null && arg is T) {
+            return arg
+        }
+
+        onError()
+        // This will always fail which is why default() should deal with errors
+        return arg as T
     }
 
     inline fun <reified T> fromList(index: Int, vararg indexes: Int): List<T?> {

--- a/src/main/kotlin/com/supergrecko/questionbot/tools/Arguments.kt
+++ b/src/main/kotlin/com/supergrecko/questionbot/tools/Arguments.kt
@@ -2,6 +2,15 @@ package com.supergrecko.questionbot.tools
 
 open class Arguments(val args: List<Any?>) {
 
+    /**
+     * Get an item from the argument list as type T.
+     *
+     * If item is not T or is null then `onError` will be ran and the final
+     * cast will always fail.
+     *
+     * @param index the index in the list to grab from
+     * @param onError the error handler if item isn't there
+     */
     inline fun <reified T> asType(index: Int, onError: () -> Unit = {}): T {
         val arg = args.getOrNull(index)
 
@@ -14,8 +23,18 @@ open class Arguments(val args: List<Any?>) {
         return arg as T
     }
 
-    inline fun <reified T> fromList(index: Int, vararg indexes: Int): List<T?> {
-        return indexes.map { (args.getOrNull(index) as? List<*>)?.getOrNull(it) as? T }
+    /**
+     * Pick a couple indexes from a List<*> inside the args.
+     *
+     * @param index index in args where List<*> is.
+     * @param indexes the indexes in the List<*> to pick from
+     * @param onError error handler if any of the items are null
+     */
+    inline fun <reified T> fromList(index: Int, vararg indexes: Int, onError: (i: Any?) -> Unit = {}): List<T?> {
+        val result = indexes.map { (args.getOrNull(index) as? List<*>)?.getOrNull(it) as? T }
+        result.filter { it == null }.forEach { item -> onError(item) }
+
+        return result
     }
 
 }


### PR DESCRIPTION
Changes in this PR:

- asType will always return T. If arg is not T then onError() will be ran and an invalid cast will be returned
- fromList can now grab an error handler as the final argument which will be ran on each item which is null.