### PR TITLE
feature(0.0.0): implement edit and delete answer commands

### DIFF
--- a/commands.md
+++ b/commands.md
@@ -21,14 +21,14 @@
 | setrole       | Role                   | Set the lowest required role to invoke commands.                  |
 
 ## answer
-| Commands | Arguments      | Description       |
-| -------- | -------------- | ----------------- |
-| answer   | Question, Text | Answer a question |
+| Commands | Arguments      | Description                  |
+| -------- | -------------- | ---------------------------- |
+| answer   | Question, Text | Answer a question            |
+| edit     | Question, Text | Edit an answer to a question |
 
 ## ask
-| Commands       | Arguments                                | Description                 |
-| -------------- | ---------------------------------------- | --------------------------- |
-| ask            | (Separated\|Text)                        | Ask the channel a question. |
-| deletequestion | Question                                 | Delete a question           |
-| question       | ChoiceArg, Question, ((Separated\|Text)) | Edit or delete a question   |
+| Commands | Arguments                                | Description                 |
+| -------- | ---------------------------------------- | --------------------------- |
+| ask      | (Separated\|Text)                        | Ask the channel a question. |
+| question | ChoiceArg, Question, ((Separated\|Text)) | Edit or delete a question   |
 

--- a/commands.md
+++ b/commands.md
@@ -20,15 +20,16 @@
 | setprefix     | Word                   | Sets the bot prefix.                                              |
 | setrole       | Role                   | Set the lowest required role to invoke commands.                  |
 
-## answer
-| Commands | Arguments      | Description                  |
-| -------- | -------------- | ---------------------------- |
-| answer   | Question, Text | Answer a question            |
-| edit     | Question, Text | Edit an answer to a question |
-
 ## ask
 | Commands | Arguments                                | Description                 |
 | -------- | ---------------------------------------- | --------------------------- |
 | ask      | (Separated\|Text)                        | Ask the channel a question. |
 | question | ChoiceArg, Question, ((Separated\|Text)) | Edit or delete a question   |
+
+## answer
+| Commands | Arguments      | Description                    |
+| -------- | -------------- | ------------------------------ |
+| answer   | Question, Text | Answer a question              |
+| delete   | Question       | Delete an answer to a question |
+| edit     | Question, Text | Edit an answer to a question   |
 

--- a/src/main/kotlin/com/supergrecko/questionbot/commands/AnswerCommands.kt
+++ b/src/main/kotlin/com/supergrecko/questionbot/commands/AnswerCommands.kt
@@ -37,4 +37,27 @@ fun answerCommands(config: ConfigService, answerService: AnswerService) = comman
             }
         }
     }
+
+    command("edit") {
+        description = "Edit an answer to a question"
+        requiresGuild = true
+        permission = PermissionLevel.EVERYONE
+
+        expect(QuestionArg, SentenceArg)
+
+        execute {
+            val args = Arguments(it.args)
+            val question = args.asType<Question>(0)
+            val answer = args.asType<String>(1)
+            val details = AnswerDetails(it.author, it.message.id, question!!.id, answer!!)
+
+            if (answerService.questionAnsweredByUser(it.guild!!, details)) {
+                answerService.editAnswer(it.guild!!, details)
+                it.respond("Your answer was updated.")
+            } else {
+                it.respond("You have not answered Question#${question!!.id}.")
+            }
+
+        }
+    }
 }

--- a/src/main/kotlin/com/supergrecko/questionbot/commands/AnswerCommands.kt
+++ b/src/main/kotlin/com/supergrecko/questionbot/commands/AnswerCommands.kt
@@ -60,4 +60,26 @@ fun answerCommands(config: ConfigService, answerService: AnswerService) = comman
 
         }
     }
+
+    command("delete") {
+        description = "Delete an answer to a question"
+        requiresGuild = true
+        permission = PermissionLevel.EVERYONE
+
+        expect(QuestionArg)
+
+        execute {
+            val args = Arguments(it.args)
+            val question = args.asType<Question>(0)
+            val details = AnswerDetails(it.author, it.message.id, question!!.id)
+
+            if (answerService.questionAnsweredByUser(it.guild!!, details)) {
+                answerService.deleteAnswer(it.guild!!, details)
+                it.respond("Your answer was deleted.")
+            } else {
+                it.respond("You have not answered Question#${question!!.id}.")
+            }
+
+        }
+    }
 }

--- a/src/main/kotlin/com/supergrecko/questionbot/dataclasses/BotConfig.kt
+++ b/src/main/kotlin/com/supergrecko/questionbot/dataclasses/BotConfig.kt
@@ -76,8 +76,8 @@ data class Question(
         this.note = note
         this.question = question
     }
-
     fun addAnswer(answer: Answer) = responses.add(answer)
+    fun getAnswerByAuthor(authorId: String) = responses.find{ it -> it.sender == authorId }
 }
 
 /**
@@ -99,8 +99,11 @@ data class Answer(
     fun setEmbedId(embedId: String) {
         this.embed = embedId
     }
-
     fun setInvocationId(invocationId: String) {
         this.invocation = invocationId
+    }
+    fun update(embed: String, invocation: String) {
+        this.embed = embed
+        this.invocation = invocation
     }
 }

--- a/src/main/kotlin/com/supergrecko/questionbot/dataclasses/BotConfig.kt
+++ b/src/main/kotlin/com/supergrecko/questionbot/dataclasses/BotConfig.kt
@@ -78,6 +78,7 @@ data class Question(
     }
     fun addAnswer(answer: Answer) = responses.add(answer)
     fun getAnswerByAuthor(authorId: String) = responses.find{ it -> it.sender == authorId }
+    fun deleteAnswerByAuthor(authorId: String) = responses.removeAll{ it.sender == authorId }
 }
 
 /**

--- a/src/main/kotlin/com/supergrecko/questionbot/services/AnswerService.kt
+++ b/src/main/kotlin/com/supergrecko/questionbot/services/AnswerService.kt
@@ -55,22 +55,39 @@ class AnswerService(val config: ConfigService) {
     }
 
     /**
-     * Edits a question with the given guild and sends updated question to the given guild
+     * Edits an answer with the given answer details
      *
      * @param guild the guild to send a question from
-     * @param newText the new answer text
-     * @param embedId the id of the embed in the answers channel
+     * @param answerDetails the answer details for the answer
      */
     fun editAnswer(guild: Guild, answerDetails: AnswerDetails) {
         val state = config.getGuild(guild.id)
         val question = state.getQuestion(answerDetails.questionId)
-        val message = question.getAnswerByAuthor(answerDetails.sender.id)
+        val answerToUpdate = question.getAnswerByAuthor(answerDetails.sender.id)
         val channel = guild.getTextChannelById(state.config.channels.answers) ?: guild.textChannels.first()
 
-        message?.setInvocationId(answerDetails.invocationId)
+        answerToUpdate?.setInvocationId(answerDetails.invocationId)
         config.save()
 
-        channel.editMessageById(message!!.embed, getEmbed(state, answerDetails)).queue()
+        channel.editMessageById(answerToUpdate!!.embed, getEmbed(state, answerDetails)).queue()
+    }
+
+    /**
+     * Deletes a question from the given guild
+     *
+     * @param guild the guild to delete from
+     * @param answerDetails the answer details for the answer
+     */
+    fun deleteAnswer(guild: Guild, answerDetails: AnswerDetails) {
+        val state = config.getGuild(guild.id)
+        val question = state.getQuestion(answerDetails.questionId)
+        val answerToDelete = question.getAnswerByAuthor(answerDetails.sender.id)
+        val channel = guild.getTextChannelById(state.config.channels.answers) ?: guild.textChannels.first()
+
+        question.deleteAnswerByAuthor(answerDetails.sender.id)
+        config.save()
+
+        channel.deleteMessageById(answerToDelete!!.embed).queue()
     }
 
     /**

--- a/src/main/kotlin/com/supergrecko/questionbot/services/AnswerService.kt
+++ b/src/main/kotlin/com/supergrecko/questionbot/services/AnswerService.kt
@@ -73,7 +73,7 @@ class AnswerService(val config: ConfigService) {
     }
 
     /**
-     * Deletes a question from the given guild
+     * Deletes an answer to a given question from the given guild
      *
      * @param guild the guild to delete from
      * @param answerDetails the answer details for the answer

--- a/src/main/kotlin/com/supergrecko/questionbot/services/AnswerService.kt
+++ b/src/main/kotlin/com/supergrecko/questionbot/services/AnswerService.kt
@@ -7,6 +7,7 @@ import com.supergrecko.questionbot.dataclasses.Question
 import me.aberrantfox.kjdautils.api.annotation.Service
 import me.aberrantfox.kjdautils.api.dsl.embed
 import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.User
 import java.awt.Color
 
 /**
@@ -60,8 +61,16 @@ class AnswerService(val config: ConfigService) {
      * @param newText the new answer text
      * @param embedId the id of the embed in the answers channel
      */
-    fun editAnswer(guild: Guild, id: Int, newText: String, embedId: String) {
+    fun editAnswer(guild: Guild, answerDetails: AnswerDetails) {
+        val state = config.getGuild(guild.id)
+        val question = state.getQuestion(answerDetails.questionId)
+        val message = question.getAnswerByAuthor(answerDetails.sender.id)
+        val channel = guild.getTextChannelById(state.config.channels.answers) ?: guild.textChannels.first()
 
+        message?.setInvocationId(answerDetails.invocationId)
+        config.save()
+
+        channel.editMessageById(message!!.embed, getEmbed(state, answerDetails)).queue()
     }
 
     /**

--- a/src/main/kotlin/com/supergrecko/questionbot/services/ConfigService.kt
+++ b/src/main/kotlin/com/supergrecko/questionbot/services/ConfigService.kt
@@ -21,6 +21,7 @@ data class QGuild(
         val guild: Guild
 ) {
     fun getQuestion(id: Int) = config.questions.first { it.id == id }
+    fun getAnser(questionId: Int) = {}
 }
 
 @Service

--- a/src/main/kotlin/com/supergrecko/questionbot/services/ConfigService.kt
+++ b/src/main/kotlin/com/supergrecko/questionbot/services/ConfigService.kt
@@ -21,7 +21,6 @@ data class QGuild(
         val guild: Guild
 ) {
     fun getQuestion(id: Int) = config.questions.first { it.id == id }
-    fun getAnser(questionId: Int) = {}
 }
 
 @Service


### PR DESCRIPTION
# feature(0.0.0): implement edit and delete answer commands

Add functionality for `$edit` and `$delete` answer. These commands will edit or delete a response to a given question by the user. As the user can only answer each question once, it is safe to search the response by the author id when looking to edit or delete it.