### PR TITLE
feature(0.1.1): Error if config is not valid

### DIFF
--- a/src/main/kotlin/com/supergrecko/questionbot/QuestionBot.kt
+++ b/src/main/kotlin/com/supergrecko/questionbot/QuestionBot.kt
@@ -20,6 +20,7 @@ fun main(args: Array<String>) {
         configure {
             allowPrivateMessages = false
 
+            prefix = "$"
             deleteMode = PrefixDeleteMode.Double
             documentationSortOrder = listOf("Ask", "Answer", "Configure", "Utility")
 

--- a/src/main/kotlin/com/supergrecko/questionbot/commands/AnswerCommands.kt
+++ b/src/main/kotlin/com/supergrecko/questionbot/commands/AnswerCommands.kt
@@ -30,8 +30,9 @@ fun answerCommands(config: ConfigService, answerService: AnswerService) = comman
 
             val state = config.getGuild(it.guild?.id!!)
             val details = AnswerDetails(it.author, question.id, answer)
-            val channel = it.guild!!.getTextChannelById(state.config.channels.answers)
-                    ?: return@execute it.invalidChannel()
+
+            // This is always valid because the precondition checks the channel's existence
+            val channel = it.guild!!.getTextChannelById(state.config.channels.answers)!!
 
             if (answerService.questionAnsweredByUser(it.guild!!, details)) {
                 it.respond("You have already answered Question#${question.id}. Check ${channel.asMention}")

--- a/src/main/kotlin/com/supergrecko/questionbot/commands/AnswerCommands.kt
+++ b/src/main/kotlin/com/supergrecko/questionbot/commands/AnswerCommands.kt
@@ -4,6 +4,7 @@ import com.supergrecko.questionbot.arguments.QuestionArg
 import com.supergrecko.questionbot.dataclasses.AnswerDetails
 import com.supergrecko.questionbot.dataclasses.Question
 import com.supergrecko.questionbot.extensions.PermissionLevel
+import com.supergrecko.questionbot.extensions.invalidChannel
 import com.supergrecko.questionbot.extensions.permission
 import com.supergrecko.questionbot.services.AnswerService
 import com.supergrecko.questionbot.services.ConfigService
@@ -29,9 +30,8 @@ fun answerCommands(config: ConfigService, answerService: AnswerService) = comman
 
             val state = config.getGuild(it.guild?.id!!)
             val details = AnswerDetails(it.author, question.id, answer)
-
             val channel = it.guild!!.getTextChannelById(state.config.channels.answers)
-                    ?: it.guild!!.textChannels.first()
+                    ?: return@execute it.invalidChannel()
 
             if (answerService.questionAnsweredByUser(it.guild!!, details)) {
                 it.respond("You have already answered Question#${question.id}. Check ${channel.asMention}")

--- a/src/main/kotlin/com/supergrecko/questionbot/commands/ManageCommands.kt
+++ b/src/main/kotlin/com/supergrecko/questionbot/commands/ManageCommands.kt
@@ -4,6 +4,7 @@ import com.supergrecko.questionbot.arguments.QuestionArg
 import com.supergrecko.questionbot.dataclasses.AnswerDetails
 import com.supergrecko.questionbot.dataclasses.Question
 import com.supergrecko.questionbot.extensions.PermissionLevel
+import com.supergrecko.questionbot.extensions.invalidChannel
 import com.supergrecko.questionbot.extensions.permission
 import com.supergrecko.questionbot.services.AnswerService
 import com.supergrecko.questionbot.services.ConfigService
@@ -132,7 +133,7 @@ fun manageCommands(config: ConfigService, questions: QuestionService, answerServ
             val state = config.getGuild(it.guild?.id!!)
             val details = AnswerDetails(user, question.id, answer)
             val channel = it.guild!!.getTextChannelById(state.config.channels.answers)
-                    ?: it.guild!!.textChannels.first()
+                    ?: return@execute it.invalidChannel()
 
             if (answerService.questionAnsweredByUser(it.guild!!, details)) {
                 it.respond("User ${user.fullName()} has already submitted an answer for Question ${question.id}.")

--- a/src/main/kotlin/com/supergrecko/questionbot/commands/ManageCommands.kt
+++ b/src/main/kotlin/com/supergrecko/questionbot/commands/ManageCommands.kt
@@ -132,8 +132,9 @@ fun manageCommands(config: ConfigService, questions: QuestionService, answerServ
             val answer = args.asType<String>(2)
             val state = config.getGuild(it.guild?.id!!)
             val details = AnswerDetails(user, question.id, answer)
-            val channel = it.guild!!.getTextChannelById(state.config.channels.answers)
-                    ?: return@execute it.invalidChannel()
+
+            // This is always valid because the precondition checks the channel's existence
+            val channel = it.guild!!.getTextChannelById(state.config.channels.answers)!!
 
             if (answerService.questionAnsweredByUser(it.guild!!, details)) {
                 it.respond("User ${user.fullName()} has already submitted an answer for Question ${question.id}.")

--- a/src/main/kotlin/com/supergrecko/questionbot/dataclasses/GuildChannels.kt
+++ b/src/main/kotlin/com/supergrecko/questionbot/dataclasses/GuildChannels.kt
@@ -1,5 +1,7 @@
 package com.supergrecko.questionbot.dataclasses
 
+import net.dv8tion.jda.api.entities.Guild
+
 /**
  * Represent the output channels
  *
@@ -12,5 +14,9 @@ data class GuildChannels(
         var questions: String = "0",
         var answers: String = "0"
 ) {
-    fun valid() = logs != "0" && questions != "0" && answers != "0"
+    fun valid(guild: Guild) = listOf(
+            guild.getTextChannelById(logs),
+            guild.getTextChannelById(questions),
+            guild.getTextChannelById(answers)
+    ).none { it == null }
 }

--- a/src/main/kotlin/com/supergrecko/questionbot/dataclasses/GuildChannels.kt
+++ b/src/main/kotlin/com/supergrecko/questionbot/dataclasses/GuildChannels.kt
@@ -11,4 +11,6 @@ data class GuildChannels(
         var logs: String = "0",
         var questions: String = "0",
         var answers: String = "0"
-)
+) {
+    fun valid() = logs != "0" && questions != "0" && answers != "0"
+}

--- a/src/main/kotlin/com/supergrecko/questionbot/extensions/CommandEvent.kt
+++ b/src/main/kotlin/com/supergrecko/questionbot/extensions/CommandEvent.kt
@@ -1,0 +1,7 @@
+package com.supergrecko.questionbot.extensions
+
+import me.aberrantfox.kjdautils.api.dsl.CommandEvent
+
+fun CommandEvent.invalidChannel() {
+    respond("The configuration channels are invalid. Please refer to the documentation for how to set up these. <https://github.com/supergrecko/QuestionBot/blob/master/docs/command-manage.md#setchannel-admin-only>")
+}

--- a/src/main/kotlin/com/supergrecko/questionbot/preconditions/ConfigPrecondition.kt
+++ b/src/main/kotlin/com/supergrecko/questionbot/preconditions/ConfigPrecondition.kt
@@ -1,0 +1,18 @@
+package com.supergrecko.questionbot.preconditions
+
+import com.supergrecko.questionbot.services.ConfigService
+import me.aberrantfox.kjdautils.api.dsl.Precondition
+import me.aberrantfox.kjdautils.api.dsl.precondition
+import me.aberrantfox.kjdautils.internal.command.Fail
+import me.aberrantfox.kjdautils.internal.command.Pass
+
+@Precondition
+fun configIsSetup(config: ConfigService) = precondition {
+    val state = config.getGuild(it.guild!!.id)
+
+    if (!state.config.channels.valid()) {
+        return@precondition Fail("The configuration channels have not been set up yet. Please refer to the documentation for how to set up these. <https://github.com/supergrecko/QuestionBot/blob/master/docs/command-manage.md#setchannel-admin-only>")
+    }
+
+    return@precondition Pass
+}

--- a/src/main/kotlin/com/supergrecko/questionbot/preconditions/ConfigPrecondition.kt
+++ b/src/main/kotlin/com/supergrecko/questionbot/preconditions/ConfigPrecondition.kt
@@ -3,14 +3,15 @@ package com.supergrecko.questionbot.preconditions
 import com.supergrecko.questionbot.services.ConfigService
 import me.aberrantfox.kjdautils.api.dsl.Precondition
 import me.aberrantfox.kjdautils.api.dsl.precondition
+import me.aberrantfox.kjdautils.discord.Discord
 import me.aberrantfox.kjdautils.internal.command.Fail
 import me.aberrantfox.kjdautils.internal.command.Pass
 
 @Precondition
-fun configIsSetup(config: ConfigService) = precondition {
+fun configIsSetup(config: ConfigService, discord: Discord) = precondition {
     val state = config.getGuild(it.guild!!.id)
 
-    if (!state.config.channels.valid()) {
+    if (!state.config.channels.valid(state.guild)) {
         return@precondition Fail("The configuration channels have not been set up yet. Please refer to the documentation for how to set up these. <https://github.com/supergrecko/QuestionBot/blob/master/docs/command-manage.md#setchannel-admin-only>")
     }
 

--- a/src/main/kotlin/com/supergrecko/questionbot/preconditions/ConfigPrecondition.kt
+++ b/src/main/kotlin/com/supergrecko/questionbot/preconditions/ConfigPrecondition.kt
@@ -7,11 +7,11 @@ import me.aberrantfox.kjdautils.discord.Discord
 import me.aberrantfox.kjdautils.internal.command.Fail
 import me.aberrantfox.kjdautils.internal.command.Pass
 
-@Precondition
+@Precondition(10)
 fun configIsSetup(config: ConfigService, discord: Discord) = precondition {
     val state = config.getGuild(it.guild!!.id)
 
-    if (!state.config.channels.valid(state.guild)) {
+    if (!state.config.channels.valid(state.guild) && it.commandStruct.commandName != "setchannel") {
         return@precondition Fail("The configuration channels have not been set up yet. Please refer to the documentation for how to set up these. <https://github.com/supergrecko/QuestionBot/blob/master/docs/command-manage.md#setchannel-admin-only>")
     }
 

--- a/src/main/kotlin/com/supergrecko/questionbot/preconditions/PermissionCondition.kt
+++ b/src/main/kotlin/com/supergrecko/questionbot/preconditions/PermissionCondition.kt
@@ -16,7 +16,7 @@ import me.aberrantfox.kjdautils.internal.command.Pass
  * @param config dependency injected config
  * @param logger dependency injected logger
  */
-@Precondition
+@Precondition(20)
 fun canInvoke(config: ConfigService, logger: LogService) = precondition {
     val state = config.getGuild(it.guild!!.id)
 

--- a/src/main/kotlin/com/supergrecko/questionbot/services/QuestionService.kt
+++ b/src/main/kotlin/com/supergrecko/questionbot/services/QuestionService.kt
@@ -93,7 +93,8 @@ class QuestionService(val config: ConfigService, private val discord: Discord) {
         val state = config.getGuild(guild.id)
         val question = state.getQuestion(id)
 
-        val channel = guild.getTextChannelById(state.config.channels.questions) ?: guild.textChannels.first()
+        // This is always valid because the precondition checks the channel's existence
+        val channel = guild.getTextChannelById(state.config.channels.questions)!!
 
         channel.sendMessage(getEmbed(state, question)).queue {
             state.getQuestion(id).messageSnowflake = it.id


### PR DESCRIPTION
This PR introduces a new Precondition which tests if the channels for the given guild is valid. If they are not it will let you know to set them up.

This means we can be fully certain the config channels exist when working with them.